### PR TITLE
修复异步加载问题

### DIFF
--- a/mod.js
+++ b/mod.js
@@ -1,7 +1,7 @@
 /**
  * file: mod.js
- * ver: 1.0.7
- * update: 2014/4/14
+ * ver: 1.0.8
+ * update: 2014/11/7
  *
  * https://github.com/zjcqoo/mod
  */
@@ -137,7 +137,17 @@ var require, define;
                 // skip loading or loaded
                 //
                 var dep = depArr[i];
-                if (dep in factoryMap || dep in needMap) {
+
+                if (dep in factoryMap){
+                    // check whether loaded resource's deps is loaded or not
+                    var child = resMap[dep];
+                    if (child && 'deps' in child) {
+                        findNeed(child.deps);
+                    }
+                    continue;
+                }
+
+                if (dep in needMap) {
                     continue;
                 }
 


### PR DESCRIPTION
问题描述：当一个资源A与资源B被打包在一起时，异步加载A的时候，A与B都会被加载，但是只有A的依赖会同时也加载，B的依赖则不会被加载，而在异步加载B的时候，会由于B本身已经被加载了，略过了依赖检查阶段，导致B的依赖加载补全

@zjcqoo @2betop 看看这样改是否可行，会造成的影响是async的资源每次都会去检查一次依赖，可能可以考虑添加一些“依赖加载完成”的标示来改进性能
